### PR TITLE
Move `CardinalityEstimatorTrait` to be only used by benchmarks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cardinality-estimator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "amadeus-streaming",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardinality-estimator"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Alex Bocharov <bocharov.alexandr@gmail.com>"]
 description = "A crate for estimating the cardinality of distinct elements in a stream or dataset."

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,10 @@ build:
 test:
 	cargo test --features with_serde
 
+bench: export RUSTFLAGS = -C target-cpu=native
+bench: export N = 1048576
+bench: export BENCH_RESULTS_PATH = target/bench_results/$(shell date '+%Y%m%d_%H%M%S')
 bench:
-	cargo criterion --bench cardinality_estimator
-
-bench-extended: export RUSTFLAGS = -C target-cpu=native
-bench-extended: export N = 1048576
-bench-extended: export BENCH_RESULTS_PATH = target/bench_results/$(shell date '+%Y%m%d_%H%M%S')
-bench-extended:
 	mkdir -p $(BENCH_RESULTS_PATH)
 	cargo criterion --bench cardinality_estimator --message-format json | tee $(BENCH_RESULTS_PATH)/results.json
 	python3 benches/analyze.py

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cargo install cargo-criterion
 
 Then benchmarks with output format JSON to save results for further analysis:
 ```shell
-make bench-extended
+make bench
 ```
 
 We've benchmarked cardinality-estimator against several other crates in the ecosystem:

--- a/benches/cardinality_estimator.rs
+++ b/benches/cardinality_estimator.rs
@@ -1,9 +1,9 @@
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-use std::hash::BuildHasherDefault;
+use std::hash::{BuildHasherDefault, Hash};
 
-use cardinality_estimator::{CardinalityEstimator, CardinalityEstimatorTrait};
+use cardinality_estimator::CardinalityEstimator;
 use criterion::measurement::WallTime;
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
@@ -43,7 +43,7 @@ fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("insert");
     for &cardinality in &cardinalities {
         group.throughput(Throughput::Elements(cardinality.max(1) as u64));
-        bench_insert::<CardinalityEstimator<usize>>(&mut group, cardinality);
+        bench_insert::<CardinalityEstimatorMut>(&mut group, cardinality);
         bench_insert::<AmadeusStreamingEstimator>(&mut group, cardinality);
         bench_insert::<ProbabilisticCollections>(&mut group, cardinality);
         bench_insert::<HyperLogLog>(&mut group, cardinality);
@@ -54,7 +54,7 @@ fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("estimate");
     group.throughput(Throughput::Elements(1));
     for &cardinality in &cardinalities {
-        bench_estimate::<CardinalityEstimator<usize>>(&mut group, cardinality);
+        bench_estimate::<CardinalityEstimatorMut>(&mut group, cardinality);
         bench_estimate::<AmadeusStreamingEstimator>(&mut group, cardinality);
         bench_estimate::<ProbabilisticCollections>(&mut group, cardinality);
         bench_estimate::<HyperLogLog>(&mut group, cardinality);
@@ -66,7 +66,7 @@ fn benchmark(c: &mut Criterion) {
         .iter()
         .map(|&cardinality| StatRecord {
             cardinality,
-            cardinality_estimator: measure_allocations::<CardinalityEstimator<usize>>(cardinality),
+            cardinality_estimator: measure_allocations::<CardinalityEstimatorMut>(cardinality),
             amadeus_streaming: measure_allocations::<AmadeusStreamingEstimator>(cardinality),
             probabilistic_collections: measure_allocations::<ProbabilisticCollections>(cardinality),
             hyperloglog: measure_allocations::<HyperLogLog>(cardinality),
@@ -85,7 +85,7 @@ fn benchmark(c: &mut Criterion) {
         .iter()
         .map(|&cardinality| StatRecord {
             cardinality,
-            cardinality_estimator: measure_error::<CardinalityEstimator<usize>>(cardinality),
+            cardinality_estimator: measure_error::<CardinalityEstimatorMut>(cardinality),
             amadeus_streaming: measure_error::<AmadeusStreamingEstimator>(cardinality),
             probabilistic_collections: measure_error::<ProbabilisticCollections>(cardinality),
             hyperloglog: measure_error::<HyperLogLog>(cardinality),
@@ -99,6 +99,15 @@ fn benchmark(c: &mut Criterion) {
         Table::new(results).with(table_config).to_string(),
     )
     .unwrap();
+}
+
+/// Cardinality estimator trait representing common estimator operations.
+trait CardinalityEstimatorTrait<T: Hash + ?Sized> {
+    fn new() -> Self;
+    fn insert(&mut self, item: &T);
+    fn estimate(&mut self) -> usize;
+    fn merge(&mut self, rhs: &Self);
+    fn name() -> String;
 }
 
 fn bench_insert<E: CardinalityEstimatorTrait<usize>>(
@@ -184,6 +193,30 @@ struct StatRecord {
     probabilistic_collections: String,
     hyperloglog: String,
     hyperloglogplus: String,
+}
+
+struct CardinalityEstimatorMut(CardinalityEstimator<usize>);
+
+impl CardinalityEstimatorTrait<usize> for CardinalityEstimatorMut {
+    fn new() -> Self {
+        Self(CardinalityEstimator::new())
+    }
+
+    fn insert(&mut self, item: &usize) {
+        self.0.insert(item);
+    }
+
+    fn estimate(&mut self) -> usize {
+        self.0.estimate()
+    }
+
+    fn merge(&mut self, rhs: &Self) {
+        self.0.merge(&rhs.0);
+    }
+
+    fn name() -> String {
+        "cardinality-estimator".to_string()
+    }
 }
 
 struct AmadeusStreamingEstimator(amadeus_streaming::HyperLogLog<usize>);

--- a/benches/requirements.txt
+++ b/benches/requirements.txt
@@ -1,5 +1,4 @@
 chdb==1.1.0
-jupyterlab==4.0.9
 matplotlib==3.8.2
 numpy==1.26.2
 pandas==2.1.4

--- a/examples/estimator.rs
+++ b/examples/estimator.rs
@@ -1,4 +1,4 @@
-use cardinality_estimator::{CardinalityEstimator, CardinalityEstimatorTrait};
+use cardinality_estimator::CardinalityEstimator;
 
 fn main() {
     let mut estimator1 = CardinalityEstimator::<usize>::new();

--- a/fuzz/fuzz_targets/estimator.rs
+++ b/fuzz/fuzz_targets/estimator.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use cardinality_estimator::estimator::{CardinalityEstimator, CardinalityEstimatorTrait};
+use cardinality_estimator::estimator::CardinalityEstimator;
 use libfuzzer_sys::fuzz_target;
 use wyhash::wyhash;
 

--- a/fuzz/fuzz_targets/serde.rs
+++ b/fuzz/fuzz_targets/serde.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use cardinality_estimator::estimator::{CardinalityEstimator, CardinalityEstimatorTrait};
+use cardinality_estimator::estimator::CardinalityEstimator;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/src/representation.rs
+++ b/src/representation.rs
@@ -6,7 +6,7 @@ use crate::array::{Array, MAX_CAPACITY};
 use crate::hyperloglog::HyperLogLog;
 use crate::representation::RepresentationError::*;
 use crate::small::Small;
-use crate::{CardinalityEstimator, CardinalityEstimatorTrait};
+use crate::CardinalityEstimator;
 
 /// Masks used for storing and retrieving representation type stored in lowest 2 bits of `data` field.
 const REPRESENTATION_MASK: usize = 0x0000_0000_0000_0003;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -82,7 +82,6 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::estimator::CardinalityEstimatorTrait;
     use test_case::test_case;
 
     #[test_case(0; "empty set")]


### PR DESCRIPTION
This trait was needed for benchmarks in the first place, so moving it there to simplify package usability.