### PR TITLE
Use const block for compile-time assertion

### DIFF
--- a/src/estimator.rs
+++ b/src/estimator.rs
@@ -27,15 +27,11 @@ where
     T: Hash + ?Sized,
     H: Hasher + Default,
 {
-    /// Ensure that `P` and `W` are in correct range at compile time
-    const VALID_PARAMS: () = assert!(P >= 4 && P <= 18 && W >= 4 && W <= 6);
-
     /// Creates new instance of `CardinalityEstimator`
     #[inline]
     pub fn new() -> Self {
-        // compile time check of params
-        #[allow(clippy::let_unit_value)]
-        let _ = Self::VALID_PARAMS;
+        // Ensure that `P` and `W` are in correct range at compile time
+        const { assert!(P >= 4 && P <= 18 && W >= 4 && W <= 6) }
 
         Self {
             // Start with empty small representation


### PR DESCRIPTION
[Version 1.79.0](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html#inline-const-expressions) of Rust introduces the const block for inline const expressions. This is a small change to remove the unit-value check found in `CardinalityEstimator`.