### PR TITLE
Fuzz: serialization heap buffer overflow via round-trip and deserialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 dhat = "0.3.3"
 hyperloglog = "1.0.2"
 hyperloglogplus = "0.4.1"
+postcard = { version = "1.1.1", features=["alloc"] }
 pprof = { version = "0.14.0", features = ["flamegraph", "criterion", "protobuf-codec"] }
 probabilistic-collections = "0.7.0"
 rand = "0.8.5"

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,15 @@ fuzz-estimator:
 fuzz-serde:
 	RUSTFLAGS="-Z sanitizer=address" cargo +nightly fuzz run serde -- -max_len=65536
 
+fuzz-serde-json-array:
+	RUSTFLAGS="-Z sanitizer=address" cargo +nightly fuzz run serde_json_array -- -max_len=65536
+
+fuzz-serde-postcard:
+	RUSTFLAGS="-Z sanitizer=address" cargo +nightly fuzz run serde_postcard -- -max_len=65536
+
+fuzz-serde-roundtrip:
+	RUSTFLAGS="-Z sanitizer=address" cargo +nightly fuzz run serde_roundtrip -- -max_len=65536
+
 lint:
 	cargo clippy --features with_serde -- -D warnings
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1", features = ["derive"] }
 cardinality-estimator = { path = "..", features = ["with_serde"] }
 libfuzzer-sys = "0.4"
 postcard = { version = "1.1.1", features = ["alloc"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,6 +29,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "serde_json_array"
+path = "fuzz_targets/serde_json_array.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "serde_postcard"
 path = "fuzz_targets/serde_postcard.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 cardinality-estimator = { path = "..", features = ["with_serde"] }
 libfuzzer-sys = "0.4"
+postcard = { version = "1.1.1", features = ["alloc"] }
 serde_json = "1.0.115"
 wyhash = "0.5.0"
 
@@ -23,6 +24,13 @@ bench = false
 [[bin]]
 name = "serde"
 path = "fuzz_targets/serde.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "serde_postcard"
+path = "fuzz_targets/serde_postcard.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = { version = "1", features = ["derive"] }
 cardinality-estimator = { path = "..", features = ["with_serde"] }
 libfuzzer-sys = "0.4"
 postcard = { version = "1.1.1", features = ["alloc"] }
@@ -38,6 +39,13 @@ bench = false
 [[bin]]
 name = "serde_postcard"
 path = "fuzz_targets/serde_postcard.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "serde_roundtrip"
+path = "fuzz_targets/serde_roundtrip.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/serde_json_array.rs
+++ b/fuzz/fuzz_targets/serde_json_array.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use serde_json::Value;
+use cardinality_estimator::estimator::CardinalityEstimator;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // pretty naiive version, u8s directly into each number position
+    let json: serde_json::Value = match data.len() {
+        0 => Value::Array(vec![]),
+        1 => Value::Array(vec![data[0].into()]),
+        _ => Value::Array(vec![data[0].into(),
+            Value::Array(data[1..].iter().map(|n| (*n).into()).collect())]),
+    };
+    if let Ok(mut estimator) = serde_json::from_value::<CardinalityEstimator<usize>>(json) {
+        estimator.insert(&1);
+        assert!(estimator.estimate() > 0);
+    }
+});

--- a/fuzz/fuzz_targets/serde_postcard.rs
+++ b/fuzz/fuzz_targets/serde_postcard.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use cardinality_estimator::estimator::CardinalityEstimator;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(mut estimator) = postcard::from_bytes::<CardinalityEstimator<usize>>(data) {
+        estimator.insert(&1);
+        assert!(estimator.estimate() > 0);
+    }
+});

--- a/fuzz/fuzz_targets/serde_roundtrip.rs
+++ b/fuzz/fuzz_targets/serde_roundtrip.rs
@@ -1,21 +1,15 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
 use cardinality_estimator::estimator::CardinalityEstimator;
 use libfuzzer_sys::fuzz_target;
+use postcard::{to_allocvec, from_bytes};
 
-#[derive(Arbitrary, Hash, PartialEq, Debug)]
-struct Datum(usize);
-
-#[derive(Arbitrary, Debug)]
-struct Data(Vec<Datum>);
-
-fuzz_target!(|data: Data| {
-    let mut estimator = CardinalityEstimator::<Datum>::new();
-    for d in &data.0 {
+fuzz_target!(|data: &[u8]| {
+    let mut estimator = CardinalityEstimator::<u8>::new();
+    for d in data {
         estimator.insert(&d);
     }
-    let serialized = postcard::to_allocvec(&estimator).unwrap();
-    let mut roundtripped: CardinalityEstimator<Datum> = postcard::from_bytes(&serialized).unwrap();
-    roundtripped.insert(&Datum(1));
+    let serialized = to_allocvec(&estimator).unwrap();
+    let mut roundtripped: CardinalityEstimator<u8> = from_bytes(&serialized).unwrap();
+    roundtripped.insert(&1);
 });

--- a/fuzz/fuzz_targets/serde_roundtrip.rs
+++ b/fuzz/fuzz_targets/serde_roundtrip.rs
@@ -1,0 +1,31 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use cardinality_estimator::estimator::CardinalityEstimator;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Hash, PartialEq, Debug)]
+struct Datum(usize);
+
+#[derive(Arbitrary, Debug)]
+struct Data(Vec<Datum>);
+
+fuzz_target!(|data: Data| {
+    let mut estimator = CardinalityEstimator::<Datum>::new();
+    for d in &data.0 {
+        estimator.insert(&d);
+    }
+    let before_estimate = estimator.estimate();
+
+    let serialized = postcard::to_allocvec(&estimator).unwrap();
+    let mut roundtripped = postcard::from_bytes::<CardinalityEstimator<Datum>>(&serialized).unwrap();
+    assert_eq!(before_estimate, roundtripped.estimate());
+
+    roundtripped.insert(&Datum(1));
+
+    let before_estimate = roundtripped.estimate();
+    let mut serialized = serde_json::to_string(&roundtripped).unwrap();
+    serialized += " ";
+    let roundtripped2: CardinalityEstimator<Datum> = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(before_estimate, roundtripped2.estimate());
+});

--- a/fuzz/fuzz_targets/serde_roundtrip.rs
+++ b/fuzz/fuzz_targets/serde_roundtrip.rs
@@ -15,17 +15,7 @@ fuzz_target!(|data: Data| {
     for d in &data.0 {
         estimator.insert(&d);
     }
-    let before_estimate = estimator.estimate();
-
     let serialized = postcard::to_allocvec(&estimator).unwrap();
-    let mut roundtripped = postcard::from_bytes::<CardinalityEstimator<Datum>>(&serialized).unwrap();
-    assert_eq!(before_estimate, roundtripped.estimate());
-
+    let mut roundtripped: CardinalityEstimator<Datum> = postcard::from_bytes(&serialized).unwrap();
     roundtripped.insert(&Datum(1));
-
-    let before_estimate = roundtripped.estimate();
-    let mut serialized = serde_json::to_string(&roundtripped).unwrap();
-    serialized += " ";
-    let roundtripped2: CardinalityEstimator<Datum> = serde_json::from_str(&serialized).unwrap();
-    assert_eq!(before_estimate, roundtripped2.estimate());
 });

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -110,6 +110,22 @@ pub mod tests {
             original_estimator.representation(),
             deserialized_estimator.representation()
         );
+
+        // run each case with postcard serialization as well
+
+        let postcard_serialized = postcard::to_allocvec(&original_estimator).expect("serialization failed");
+        assert!(
+            !postcard_serialized.is_empty(),
+            "postcard_serialized bytes should not be empty"
+        );
+
+        let postcard_estimator: CardinalityEstimator<str> =
+            postcard::from_bytes(&postcard_serialized).expect("deserialization failed");
+
+        assert_eq!(
+            original_estimator.representation(),
+            postcard_estimator.representation()
+        );
     }
 
     #[test]
@@ -129,6 +145,9 @@ pub mod tests {
     #[test_case(&[91, 51, 44, 10, 110, 117, 108, 108, 93]; "case 4")]
     fn test_failed_deserialization(input: &[u8]) {
         let result: Result<CardinalityEstimator<str>, _> = serde_json::from_slice(input);
+        assert!(result.is_err());
+
+        let result: Result<CardinalityEstimator<str>, _> = postcard::from_bytes(input);
         assert!(result.is_err());
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -113,7 +113,8 @@ pub mod tests {
 
         // run each case with postcard serialization as well
 
-        let postcard_serialized = postcard::to_allocvec(&original_estimator).expect("serialization failed");
+        let postcard_serialized =
+            postcard::to_allocvec(&original_estimator).expect("serialization failed");
         assert!(
             !postcard_serialized.is_empty(),
             "postcard_serialized bytes should not be empty"


### PR DESCRIPTION
Cardinality estimator makes assumptions about the values it receives when deserializing which seem to be upheld by _`serde_json`_ but not `serde` in general, leading to buffer overflows and other problems when used with other serde de/serializers.

I had the wildest crashes happening in a project, which I traced to cardinality-estimator. In narrowing down a smaller reproducible example, I found that using bincode with this library was sufficient to get buffer overflows: see https://github.com/uniphil/whose-overflow-is-it-anyway

This PR adds a fuzz target for `postcard`, whose API is close enough to `serde_json` for the change from the serde fuzz target to be a single line. It also adds postcard calls to the normal serde tests, though I wasn't able to specifically write a failing regression test case for it (I'm sure it's possible, just had to stop somewhere).

To be clear: this change only illustrates the issue and does not include a fix. Seems like fixing will require either

- fixing the deserialization logic to assume less about the inputs it receives (array alignment and length?), OR
- documenting explicitly that the `serde` support is **only** safe to work with `serde_json`.

Thanks @DavidBuchanan314 for help narrowing the source of the crashes <3