### PR TITLE
Fix heap-buffer-overflow in Array deserialization

### DIFF
--- a/src/estimator.rs
+++ b/src/estimator.rs
@@ -95,7 +95,7 @@ where
 
     /// Returns the representation type of `CardinalityEstimator`.
     #[inline]
-    pub(crate) fn representation(&self) -> Representation<P, W> {
+    pub(crate) fn representation(&self) -> Representation<'_, P, W> {
         Representation::<P, W>::from_data(self.data)
     }
 


### PR DESCRIPTION
This PR fixes a bug where Array::from_vec and Array::From<usize> disagreed on capacity calculation, causing heap-buffer-overflow when deserializing with certain serializers (e.g., bincode)
I added simple regression test for the capacity mismatch issue. 

**The Bug**
from_vec used cap = arr.len() while From<usize> assumed cap = len.next_power_of_two(). 

When deserializing 100 elements:
1. Deserializer creates Vec with capacity 100
2. from_vec stores pointer with capacity 100
3. Later, From<usize> reconstructs assuming capacity 128
4. Writing to indices 100-127 overflows the heap buffer
This affects serializers like bincode that create exact-capacity Vecs. serde_json accidentally masked the bug because push() doubles capacity.

**The Fix**
from_vec now resizes the Vec to len.next_power_of_two() before forgetting it, ensuring the allocation matches what From<usize> expects.